### PR TITLE
Remove Bandwidth Limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ ENV TOR_ORPort 9001
 ENV TOR_DirPort 9030
 ENV TOR_DataDirectory /data
 ENV TOR_ContactInfo "Random Person nobody@tor.org"
-ENV TOR_RelayBandwidthRate "100 KBytes"
-ENV TOR_RelayBandwidthBurst "200 KBytes"
 
 # Copy the default configurations.
 COPY torrc.bridge.default /config/torrc.bridge.default


### PR DESCRIPTION
Bandwidth limits set here will be forced upon every relay. Many relays don't require bandwidth limits. If relay operaters want to set bandwidths, they can do so themselves. Setting it for them, means those who don't want bandwidth limits, must clone, modify the Dockerfile, and rebuild the docker image.